### PR TITLE
ci: Run `nix flake check`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+on:
+  push:
+
+jobs:
+  lints:
+    name: Lints
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - name: run `nix flake check`
+        run: nix flake check


### PR DESCRIPTION
As a very basic sanity check, to ensure that at least all the outputs are valid & exist.